### PR TITLE
Add description support for posts

### DIFF
--- a/src/_data/metadata.js
+++ b/src/_data/metadata.js
@@ -3,7 +3,8 @@ export default {
   url: 'https://equk.co.uk',
   domain: 'equk.co.uk',
   language: 'en',
-  description: 'writings of a coder + sysadmin',
+  subtitle: 'writings of a coder + sysadmin',
+  description: `I'm equilibriumuk, a software engineer. I write about programming & computer related topics`,
   author: {
     name: 'equilibriumuk',
     photo: '/users/equilibriumuk.jpg',

--- a/src/atom/atom.njk
+++ b/src/atom/atom.njk
@@ -5,7 +5,8 @@ eleventyExcludeFromCollections: true
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.language }}">
   <title>{{ metadata.title }}</title>
-  <subtitle>{{ metadata.description }}</subtitle>
+  <subtitle>{{ metadata.subtitle }}</subtitle>
+  <description>{{ metadata.description }}</description>
   <link href="{{ permalink | htmlBaseUrl(metadata.url) }}" rel="self"/>
   <link href="{{ metadata.url | addPathPrefixToFullUrl }}" rel="alternate"/>
   <updated>{{ collections.posts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
@@ -21,6 +22,9 @@ eleventyExcludeFromCollections: true
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | dateToRfc3339 }}</updated>
     <id>{{ absolutePostUrl | addPathPrefixToFullUrl }}</id>
+    {% if post.data.excerpt %}
+    <description>{{ post.data.excerpt }}</description>
+    {% endif %}
     <summary type="html">{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | excerpt }}</summary>
   </entry>
   {%- endfor %}

--- a/src/posts/2023-07-14-Favicon Generation In Eleventy.md
+++ b/src/posts/2023-07-14-Favicon Generation In Eleventy.md
@@ -10,6 +10,7 @@ tags:
 image:
 imgAuthor:
 imgAuthorURL:
+excerpt: "Generating favicon from svg in 11ty using sharp"
 ---
 
 ![11ty logo](../_media/images/11ty-200.png)

--- a/src/posts/2023-07-18-Adding Webmentions in Eleventy.md
+++ b/src/posts/2023-07-18-Adding Webmentions in Eleventy.md
@@ -13,6 +13,7 @@ image:
 imgAuthor:
 imgAuthorURL:
 templateEngineOverride: md
+excerpt: "Adding webmentions support to 11ty using netlify hooks"
 ---
 
 ![11ty logo](../_media/images/11ty-200.png)

--- a/src/posts/2023-12-29-11ty ECMAScript Modules Support.md
+++ b/src/posts/2023-12-29-11ty ECMAScript Modules Support.md
@@ -10,6 +10,7 @@ tags:
 image:
 imgAuthor:
 imgAuthorURL:
+excerpt: "Switching to 11ty canary v3 for ECMAScript support"
 ---
 
 ![11ty logo](../_media/images/11ty-200.png)

--- a/src/posts/2024-12-06-11ty Fix Inline Styles Livereload.md
+++ b/src/posts/2024-12-06-11ty Fix Inline Styles Livereload.md
@@ -11,6 +11,7 @@ image:
 imgAuthor:
 imgAuthorURL:
 templateEngineOverride: md
+excerpt: "Fixing inline styles in 11ty devmode using a workaround"
 ---
 
 ![11ty logo](../_media/images/11ty-200.png)


### PR DESCRIPTION
Add ability to use `excerpt` field in posts for `description` used in site & atom feed generation

- [x] added new description to site metadata
- [x] added description to atom & added ability for posts to have description in atom
- [x] added small excerpt to recent posts for description

