### PR TITLE
Mastodon Post Web Component

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -23,7 +23,11 @@ export default function (eleventyConfig) {
   // Run esbuild
   eleventyConfig.on('eleventy.before', async () => {
     await esbuild.build({
-      entryPoints: ['src/_scripts/darkmode.js', 'src/_scripts/mobilenav.js'],
+      entryPoints: [
+        'src/_scripts/darkmode.js',
+        'src/_scripts/mobilenav.js',
+        'src/_scripts/mastodon.js',
+      ],
       outdir: 'src/_assets/js',
       minify: true,
       sourcemap: false,

--- a/newpost.js
+++ b/newpost.js
@@ -38,7 +38,7 @@ rl.question('Post Title:', (title) => {
     process.exit(1)
   }
 
-  const output = `---\ntitle: "${title}"\ndate: ${dateNow.toISOString()}\nauthor: ${author}\ndraft: false\ntags:\n - github\nimage:\nimgAuthor:\nimgAuthorURL:\nexcerpt:\n---\n\n`
+  const output = `---\ntitle: "${title}"\ndate: ${dateNow.toISOString()}\nauthor: ${author}\ndraft: false\ntags:\n - github\nimage:\nimgAuthor:\nimgAuthorURL:\nmastodonPostId:\nexcerpt:\n---\n\n`
 
   fs.writeFileSync(`${blogPostDate}-${title}.md`, output)
 

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -68,6 +68,10 @@ layout: layouts/base.njk
       </div>
     </section>
   </article>
-  {%- set webmentionUrl -%}{{ page.url | url | absoluteUrl( metadata.url ) }}{%- endset -%}
-  {% include 'post/webmentions.njk' %}
+    {%- if mastodonPostId %}
+    <div class="post-comments mb-10">
+      <p class="text-3xl title">Comments</p>
+      {% include 'post/mastopost.njk' %}
+    </div>
+    {% endif %}
 </main>

--- a/src/_includes/post/mastopost.njk
+++ b/src/_includes/post/mastopost.njk
@@ -21,20 +21,20 @@
         <div data-key="replyCount"></div>
       </div>
     </a>
-    <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}/favourites" target="_blank" rel="noopener noreferrer">
-      <div class="mastodon-data-count">
-        <svg class="mastodon-data-icon" aria-hidden="true">
-          <use href="#like-icon" />
-        </svg>
-        <div data-key="likeCount"></div>
-      </div>
-    </a>
     <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}/reblogs" target="_blank" rel="noopener noreferrer">
       <div class="mastodon-data-count">
         <svg class="mastodon-data-icon" aria-hidden="true">
           <use href="#boost-icon" />
         </svg>
         <div data-key="repostCount"></div>
+      </div>
+    </a>
+    <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}/favourites" target="_blank" rel="noopener noreferrer">
+      <div class="mastodon-data-count">
+        <svg class="mastodon-data-icon" aria-hidden="true">
+          <use href="#like-icon" />
+        </svg>
+        <div data-key="likeCount"></div>
       </div>
     </a>
   </div>

--- a/src/_includes/post/mastopost.njk
+++ b/src/_includes/post/mastopost.njk
@@ -6,12 +6,12 @@
         {{ metadata.author.contacts.mastodon }}
       </div>
     </a>
-    <div class="mastodon-text">{{ excerpt }}</div>
     <mastodon-post postId={{mastodonPostId}}></mastodon-post>
   </div>
 </div>
 
 <template id="mastodon-template">
+  <div class="mastodon-text" data-key="postText"></div>
   <div class="mastodon-data">
     <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}" target="_blank" rel="noopener noreferrer">
       <div class="mastodon-data-count">

--- a/src/_includes/post/mastopost.njk
+++ b/src/_includes/post/mastopost.njk
@@ -1,0 +1,57 @@
+<div class="masto-post post-comments border border-slate-200 dark:border-slate-700/40">
+  <div class="mastodon-content">
+    <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}">
+      <div class="mastodon-name">
+        <svg class="mastodon-icon" viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M11.19 12.195c2.016-.24 3.77-1.475 3.99-2.603.348-1.778.32-4.339.32-4.339 0-3.47-2.286-4.488-2.286-4.488C12.062.238 10.083.017 8.027 0h-.05C5.92.017 3.942.238 2.79.765c0 0-2.285 1.017-2.285 4.488l-.002.662c-.004.64-.007 1.35.011 2.091.083 3.394.626 6.74 3.78 7.57 1.454.383 2.703.463 3.709.408 1.823-.1 2.847-.647 2.847-.647l-.06-1.317s-1.303.41-2.767.36c-1.45-.05-2.98-.156-3.215-1.928a3.614 3.614 0 0 1-.033-.496s1.424.346 3.228.428c1.103.05 2.137-.064 3.188-.189zm1.613-2.47H11.13v-4.08c0-.859-.364-1.295-1.091-1.295-.804 0-1.207.517-1.207 1.541v2.233H7.168V5.89c0-1.024-.403-1.541-1.207-1.541-.727 0-1.091.436-1.091 1.296v4.079H3.197V5.522c0-.859.22-1.541.66-2.046.456-.505 1.052-.764 1.793-.764.856 0 1.504.328 1.933.983L8 4.39l.417-.695c.429-.655 1.077-.983 1.934-.983.74 0 1.336.259 1.791.764.442.505.661 1.187.661 2.046v4.203z"></path></svg>
+        {{ metadata.author.contacts.mastodon }}
+      </div>
+    </a>
+    <div class="mastodon-text">{{ excerpt }}</div>
+    <mastodon-post postId={{mastodonPostId}}></mastodon-post>
+  </div>
+</div>
+
+<template id="mastodon-template">
+  <div class="mastodon-data">
+    <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}" target="_blank" rel="noopener noreferrer">
+      <div class="mastodon-data-count">
+        <svg class="mastodon-data-icon" aria-hidden="true">
+          <use href="#reply-icon" />
+        </svg>
+        <div data-key="replyCount"></div>
+      </div>
+    </a>
+    <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}/favourites" target="_blank" rel="noopener noreferrer">
+      <div class="mastodon-data-count">
+        <svg class="mastodon-data-icon" aria-hidden="true">
+          <use href="#like-icon" />
+        </svg>
+        <div data-key="likeCount"></div>
+      </div>
+    </a>
+    <a href="{{ 'https://' + metadata.author.contacts.mastodon_url + '/' + mastodonPostId }}/reblogs" target="_blank" rel="noopener noreferrer">
+      <div class="mastodon-data-count">
+        <svg class="mastodon-data-icon" aria-hidden="true">
+          <use href="#boost-icon" />
+        </svg>
+        <div data-key="repostCount"></div>
+      </div>
+    </a>
+  </div>
+</template>
+
+<script type="module">{% include "src/_assets/js/mastodon.js" %}</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" class="hidden">
+  <defs>
+    <symbol id="like-icon" viewBox="0 0 20 20">
+      <path fill="currentColor" d="M1.85937 11.6166L8.91797 18.5519C9.21094 18.8397 9.59766 19 10 19C10.4023 19 10.7891 18.8397 11.082 18.5519L18.1406 11.6166C19.3281 10.4532 20 8.82115 20 7.11508V6.87665C20 4.00305 18.0273 1.55289 15.3359 1.08013C13.5547 0.767691 11.7422 1.38023 10.4688 2.72042L10 3.21374L9.53125 2.72042C8.25781 1.38023 6.44531 0.767691 4.66406 1.08013C1.97266 1.55289 0 4.00305 0 6.87665V7.11508C0 8.82115 0.671875 10.4532 1.85937 11.6166Z"></path>
+    </symbol>
+    <symbol id="reply-icon" viewBox="0 0 20 20">
+      <path fill="currentColor" d="M20 9.35714C20 13.9737 15.5237 17.7143 10.0006 17.7143C8.55144 17.7143 7.17652 17.4571 5.93441 16.9951C5.46959 17.3446 4.71182 17.8228 3.81344 18.2246C2.87599 18.6424 1.74715 19 0.626122 19C0.372231 19 0.145681 18.8433 0.0480306 18.6022C-0.04962 18.3612 0.00506435 18.0879 0.180835 17.9031L0.192554 17.8911C0.204272 17.879 0.219896 17.8629 0.243332 17.8348C0.286298 17.7866 0.352701 17.7103 0.434727 17.6058C0.594874 17.4049 0.809705 17.1076 1.02844 16.7379C1.41904 16.071 1.79012 15.1951 1.86433 14.2107C0.692525 12.8446 0.00115834 11.1692 0.00115834 9.35714C0.00115834 4.74062 4.47746 1 10.0006 1C15.5237 1 20 4.74062 20 9.35714Z"></path>
+    </symbol>
+    <symbol id="boost-icon" viewBox="0 0 20 20">
+      <path fill="currentColor" d="M7 3C6.44772 3 6 3.44772 6 4C6 4.55228 6.44772 5 7 5V3ZM13.7071 9.29289C13.3166 8.90237 12.6834 8.90237 12.2929 9.29289C11.9024 9.68342 11.9024 10.3166 12.2929 10.7071L13.7071 9.29289ZM16 13L15.2929 13.7071L16 14.4142L16.7071 13.7071L16 13ZM19.7071 10.7071C20.0976 10.3166 20.0976 9.68342 19.7071 9.29289C19.3166 8.90237 18.6834 8.90237 18.2929 9.29289L19.7071 10.7071ZM13 17C13.5523 17 14 16.5523 14 16C14 15.4477 13.5523 15 13 15V17ZM6.29289 10.7071C6.68342 11.0976 7.31658 11.0976 7.70711 10.7071C8.09763 10.3166 8.09763 9.68342 7.70711 9.29289L6.29289 10.7071ZM4 7L4.70711 6.29289L4 5.58579L3.29289 6.29289L4 7ZM0.292893 9.29289C-0.097631 9.68342 -0.0976311 10.3166 0.292893 10.7071C0.683417 11.0976 1.31658 11.0976 1.70711 10.7071L0.292893 9.29289ZM7 5H14V3H7V5ZM15 6V12H17V6H15ZM14 5C14.5523 5 15 5.44772 15 6H17C17 4.34315 15.6569 3 14 3V5ZM12.2929 10.7071L15.2929 13.7071L16.7071 12.2929L13.7071 9.29289L12.2929 10.7071ZM18.2929 9.29289L15.2929 12.2929L16.7071 13.7071L19.7071 10.7071L18.2929 9.29289ZM13 15H6V17H13V15ZM5 14V8H3V14H5ZM6 15C5.44772 15 5 14.5523 5 14H3C3 15.6569 4.34315 17 6 17V15ZM7.70711 9.29289L4.70711 6.29289L3.29289 7.70711L6.29289 10.7071L7.70711 9.29289ZM1.70711 10.7071L4.70711 7.70711L3.29289 6.29289L0.292893 9.29289L1.70711 10.7071Z"></path>
+    </symbol>
+  </defs>
+</svg>

--- a/src/_scripts/mastodon.js
+++ b/src/_scripts/mastodon.js
@@ -12,6 +12,9 @@ class MastodonPost extends HTMLElement {
     const data = { ...(await this.postData()) }
 
     if (data) {
+      node.querySelector('[data-key="postText"]').innerHTML = data.content
+        .replace(/<a.*?>/gi, '')
+        .replace(/<\/a>/gi, '')
       node.querySelector('[data-key="likeCount"]').textContent =
         data.favourites_count
       node.querySelector('[data-key="replyCount"]').textContent =

--- a/src/_scripts/mastodon.js
+++ b/src/_scripts/mastodon.js
@@ -1,0 +1,38 @@
+class MastodonPost extends HTMLElement {
+  constructor() {
+    super()
+  }
+
+  static observedAttributes = ['postId']
+
+  async connectedCallback() {
+    const template = document.querySelector('#mastodon-template')
+    const node = document.importNode(template.content, true)
+
+    const data = { ...(await this.postData()) }
+
+    if (data) {
+      node.querySelector('[data-key="likeCount"]').textContent =
+        data.favourites_count
+      node.querySelector('[data-key="replyCount"]').textContent =
+        data.replies_count
+      node.querySelector('[data-key="repostCount"]').textContent =
+        data.reblogs_count
+    }
+
+    this.append(node)
+  }
+
+  get postId() {
+    return this.getAttribute('postId')
+  }
+
+  async postData() {
+    const data = await fetch(
+      `https://hachyderm.io/api/v1/statuses/${this.postId}`
+    ).then((response) => response.json())
+    return data
+  }
+}
+
+customElements.define('mastodon-post', MastodonPost)

--- a/src/_styles/_global.css
+++ b/src/_styles/_global.css
@@ -844,6 +844,66 @@ h2+.header-anchor {
   border: 2px solid var(--theme-link);
 }
 
+/* mastodon post */
+
+.masto-post {
+  border-radius: 5px;
+  padding: 0.75rem;
+  font-size: 1rem;
+  display: flex;
+  align-items: flex-start;
+  text-decoration: none;
+}
+
+.masto-post a {
+  text-decoration: none;
+  color: var(--theme-text);
+}
+
+.masto-post a:hover {
+  text-decoration: none;
+  color: var(--theme-hover);
+}
+
+.mastodon-title {
+  margin-bottom: 0.25rem;
+}
+
+.mastodon-text {
+  margin: 0.75rem 0 0.25rem;
+  padding-left: 0.25rem;
+}
+
+.mastodon-name {
+  font-weight: 700;
+  display: flex;
+}
+
+.mastodon-icon {
+  width: 20px;
+  height: auto;
+  margin: 0 4px;
+  color: #563ACC;
+}
+
+.mastodon-data {
+  display:flex;
+  align-items: center;
+  justify-content: space-around;
+  padding-top: 10px;
+}
+
+.mastodon-data-icon {
+  display: inline-flex;
+  width: 2rem;
+  height: 1rem;
+}
+
+.mastodon-data-count {
+  display: inline-flex;
+  padding: 0 1rem;
+}
+
 /*
   -----------------------------------------
   Typography Styles

--- a/src/_styles/_global.css
+++ b/src/_styles/_global.css
@@ -879,6 +879,11 @@ h2+.header-anchor {
   padding-left: 0.25rem;
 }
 
+.mastodon-text .ellipsis,
+.mastodon-text .invisible {
+  display:none
+}
+
 .mastodon-name {
   font-weight: 700;
   display: flex;

--- a/src/_styles/_global.css
+++ b/src/_styles/_global.css
@@ -849,10 +849,15 @@ h2+.header-anchor {
 .masto-post {
   border-radius: 5px;
   padding: 0.75rem;
-  font-size: 1rem;
+  font-size: 0.9rem;
   display: flex;
   align-items: flex-start;
   text-decoration: none;
+}
+
+.masto-post p {
+  margin: 0.6em 0;
+  line-height: 1.2rem;
 }
 
 .masto-post a {
@@ -870,7 +875,7 @@ h2+.header-anchor {
 }
 
 .mastodon-text {
-  margin: 0.75rem 0 0.25rem;
+  margin: 0.5rem 0 0.25rem;
   padding-left: 0.25rem;
 }
 

--- a/src/posts/2024-12-30-Site Updates Over 2024.md
+++ b/src/posts/2024-12-30-Site Updates Over 2024.md
@@ -11,6 +11,7 @@ tags:
 image:
 imgAuthor:
 imgAuthorURL:
+mastodonPostId: "109389406260065173"
 excerpt: "Looking at site updates & fixes over the past year"
 ---
 


### PR DESCRIPTION
Add new feature for commenting on blog articles using mastodon posts.

This is a web component which simplifies commenting by embedding a single post which provides links to mastodon allowing users to comment on mastodon / fediverse.

- [x] add new field mastodonPostId for newpost creation
- [x] add new njk include for mastodon post comment component
- [x] add new client script for collecting post data from mastodon
- [x] add mastodon client script to esbuild in main eleventy config
- [x] add new styles for mastodon post comment component

