### PR TITLE
Add Obsidian & Github Style Alert Blocks

### DIFF
--- a/eleventy.config.githubalerts.js
+++ b/eleventy.config.githubalerts.js
@@ -1,0 +1,21 @@
+import GithubAlerts from 'markdown-it-github-alerts'
+
+// Github Style Callout Blocks Plugin For Markdown-it
+// https://github.com/antfu/markdown-it-github-alerts
+
+// Disable SVG Icons & Set Custom classPrefix for CSS
+export default (md) => {
+  md.use(GithubAlerts, {
+    classPrefix: 'callout-block',
+    icons: '',
+    markers: [
+      'TIP',
+      'NOTE',
+      'IMPORTANT',
+      'WARNING',
+      'CAUTION',
+      'DANGER',
+      'INFO',
+    ],
+  })
+}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -16,6 +16,7 @@ import sharp from 'sharp'
 import pluginDrafts from './eleventy.config.drafts.js'
 import pluginImages from './eleventy.config.images.js'
 import containerPlugin from './eleventy.config.markdown.js'
+import githubAlerts from './eleventy.config.githubalerts.js'
 import metadata from './src/_data/metadata.js'
 
 export default function (eleventyConfig) {
@@ -266,6 +267,7 @@ export default function (eleventyConfig) {
       slugify: eleventyConfig.getFilter('slugify'),
     })
     mdLib.use(containerPlugin)
+    mdLib.use(githubAlerts)
     mdLib.use(markdownItTaskLists, { label: true })
     mdLib.enable('code')
   })

--- a/eleventy.config.markdown.js
+++ b/eleventy.config.markdown.js
@@ -10,6 +10,7 @@ export default (md) => {
     .use(...createContainer('danger', 'Danger', md))
     .use(...createContainer('note', 'Note', md))
     .use(...createContainer('important', 'Important', md))
+    .use(...createContainer('caution', 'Caution', md))
 }
 
 function createContainer(conClass, defaultTitle, md) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "markdown-it": "^14.1.0",
     "markdown-it-anchor": "^9.2.0",
     "markdown-it-container": "^4.0.0",
+    "markdown-it-github-alerts": "^0.3.0",
     "markdown-it-task-lists": "^2.1.1",
     "postcss": "^8.5.2",
     "postcss-import": "^16.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       markdown-it-container:
         specifier: ^4.0.0
         version: 4.0.0
+      markdown-it-github-alerts:
+        specifier: ^0.3.0
+        version: 0.3.0(markdown-it@14.1.0)
       markdown-it-task-lists:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1670,6 +1673,11 @@ packages:
 
   markdown-it-container@4.0.0:
     resolution: {integrity: sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==}
+
+  markdown-it-github-alerts@0.3.0:
+    resolution: {integrity: sha512-qyIuDyfdrVGHhY+E/44yMyNA3ZnayaT/KKT2VgkIz1nmrgiuPkdgPUh4YBZwgJ9VKEGJvGd82Ndrc4oGftrJWg==}
+    peerDependencies:
+      markdown-it: ^14.0.0
 
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
@@ -4106,6 +4114,10 @@ snapshots:
       markdown-it: 14.1.0
 
   markdown-it-container@4.0.0: {}
+
+  markdown-it-github-alerts@0.3.0(markdown-it@14.1.0):
+    dependencies:
+      markdown-it: 14.1.0
 
   markdown-it-task-lists@2.1.1: {}
 

--- a/src/_styles/_global.css
+++ b/src/_styles/_global.css
@@ -723,30 +723,82 @@ article.message {
 }
 
 .callout-block.tip,
-.callout-block.note {
+.callout-block.note,
+.callout-block-note,
+.callout-block-tip {
   @apply border-sky-400 border-l-4;
 }
 
 .callout-block.tip .callout-block-title,
-.callout-block.note .callout-block-title {
+.callout-block.note .callout-block-title,
+.callout-block-tip .callout-block-title,
+.callout-block-note .callout-block-title {
   @apply text-sky-600;
 }
 
 .dark .callout-block.tip .callout-block-title,
-.dark .callout-block.note .callout-block-title {
+.dark .callout-block.note .callout-block-title,
+.dark .callout-block-tip .callout-block-title,
+.dark .callout-block-note .callout-block-title {
   @apply text-sky-400;
 }
 
-.callout-block.warning {
+.callout-block.warning,
+.callout-block-warning {
   @apply border-yellow-200 border-l-4;
 }
 
-.callout-block.warning .callout-block-title {
+.callout-block.warning .callout-block-title,
+.callout-block-warning .callout-block-title {
   @apply text-yellow-400;
 }
 
-.dark .callout-block.warning .callout-block-title {
+.dark .callout-block.warning .callout-block-title,
+.dark .callout-block-warning .callout-block-title {
   @apply text-yellow-200;
+}
+
+.callout-block-danger {
+  @apply border-red-400 border-l-4;
+}
+
+.callout-block-danger .callout-block-title {
+  @apply text-red-600;
+}
+
+.dark .callout-block-danger .callout-block-title {
+  @apply text-red-400;
+}
+
+.callout-block-important {
+  @apply border-purple-400 border-l-4;
+}
+
+.callout-block-important .callout-block-title {
+  @apply text-purple-600;
+}
+
+.dark .callout-block-important .callout-block-title {
+  @apply text-purple-400;
+}
+
+.callout-block-details {
+  @apply border-gray-400 border-l-4 bg-gray-100 text-gray-700;
+}
+
+.callout-block-caution,
+.callout-block.caution {
+  @apply border-orange-400 border-l-4;
+}
+
+.callout-block-caution .callout-block-title,
+.callout-block.caution .callout-block-title {
+  @apply text-orange-600;
+}
+
+.dark .callout-block-caution .callout-block-title,
+.dark .callout-block.caution .callout-block-title {
+  @apply text-orange-400;
 }
 
 .callout-block.danger {


### PR DESCRIPTION
This adds functionality of callout / alert blocks similar to Github & Obsidian.

eg: 

```
> [!IMPORTANT]
> Important
```

> [!IMPORTANT]
> Important

- [x] import `githubAlerts` eleventy markdown-it plugin & apply with `mdLib.use`
- [x] add custom styles for github and obsidian callout blocks
- [x] new eleventy plugin for github and obsidian style alerts for markdown-it
- [x] new dependency for github and obsidian styled callout blocks
- [x] add callout block for caution to markdown callout plugin